### PR TITLE
Setup remote mcp server for vercel deployment

### DIFF
--- a/README-MCP.md
+++ b/README-MCP.md
@@ -1,0 +1,152 @@
+# Prompto MCP Server
+
+This is a Model Context Protocol (MCP) server implementation of the Prompto CLI tool, designed to work with xmcp.dev and deployable on Vercel.
+
+## Features
+
+The MCP server exposes the following tools:
+
+- **list_prompts**: List private prompts available in LangSmith
+- **get_prompt**: Render a prompt locally with optional variables
+- **create_prompt**: Create a new LangSmith prompt
+- **update_prompt**: Update an existing prompt with new content or metadata
+- **delete_prompt**: Delete a prompt after confirming it exists
+
+## Local Development
+
+### Prerequisites
+
+1. Node.js 18+ or Bun
+2. LangSmith API key
+
+### Setup
+
+1. Clone the repository
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+3. Set your LangSmith API key:
+   ```bash
+   export LANGSMITH_API_KEY="your-api-key-here"
+   ```
+
+4. Run the development server:
+   ```bash
+   npm run dev
+   ```
+
+The server will start on http://localhost:3000
+
+### Testing the MCP Server
+
+You can test the MCP server using curl:
+
+```bash
+# Health check
+curl http://localhost:3000/health
+
+# List tools
+curl -X POST http://localhost:3000/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}'
+
+# Call a tool
+curl -X POST http://localhost:3000/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc": "2.0", "id": 2, "method": "tools/call", "params": {"name": "list_prompts"}}'
+```
+
+## Vercel Deployment
+
+### Prerequisites
+
+1. Vercel CLI installed: `npm i -g vercel`
+2. LangSmith API key configured in Vercel
+
+### Deploy Steps
+
+1. **Build the project:**
+   ```bash
+   npm run build:server
+   ```
+
+2. **Deploy to Vercel:**
+   ```bash
+   vercel
+   ```
+
+3. **Set environment variables in Vercel:**
+   - Go to your project settings in Vercel dashboard
+   - Add `LANGSMITH_API_KEY` with your LangSmith API key
+
+4. **Update the llms.txt file:**
+   - Replace `your-domain.vercel.app` with your actual Vercel domain
+   - The MCP endpoint will be at: `https://your-domain.vercel.app/mcp`
+
+### Production URLs
+
+After deployment:
+- Health check: `https://your-domain.vercel.app/health`
+- MCP endpoint: `https://your-domain.vercel.app/mcp`
+- xmcp.dev discovery: The `llms.txt` file should be accessible at the root of your domain
+
+## Integration with xmcp.dev
+
+1. Deploy your server to Vercel
+2. Update the `llms.txt` file with your production domain
+3. The server will automatically be discoverable by xmcp.dev clients
+4. Users can connect to your MCP server through the xmcp.dev interface
+
+## Configuration
+
+### Environment Variables
+
+- `LANGSMITH_API_KEY`: Your LangSmith API key (required)
+- `PORT`: Port for local development (default: 3000)
+
+### llms.txt Format
+
+The `llms.txt` file follows the xmcp.dev specification and includes:
+- Server metadata (name, description, URL)
+- Tool definitions with schemas
+- Environment variable requirements
+- Usage examples
+
+## Security Considerations
+
+- The MCP server requires a valid LangSmith API key
+- Consider implementing rate limiting for production use
+- Monitor API usage to prevent abuse
+- Use HTTPS in production (automatically handled by Vercel)
+
+## Troubleshooting
+
+### Common Issues
+
+1. **"Missing LangSmith API key"**: Ensure `LANGSMITH_API_KEY` is set in your environment
+2. **Build failures**: Make sure all dependencies are installed and TypeScript is configured correctly
+3. **CORS errors**: The server includes CORS headers, but check your client implementation
+4. **Vercel deployment issues**: Verify the `vercel.json` configuration matches your project structure
+
+### Debug Mode
+
+For detailed logging, you can modify the MCP server to include debug information:
+
+```typescript
+console.log('MCP Request:', message);
+console.log('MCP Response:', response);
+```
+
+## Contributing
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes
+4. Add tests if applicable
+5. Submit a pull request
+
+## License
+
+This project is licensed under the same terms as the original Prompto CLI tool.

--- a/api/mcp.js
+++ b/api/mcp.js
@@ -1,0 +1,294 @@
+const { createServer } = require('http');
+const { parse } = require('url');
+
+// Import the MCP server logic
+class PromptManager {
+    constructor(apiKey) {
+        this.apiKey = apiKey;
+        // Simplified manager for server deployment
+    }
+
+    async listPrompts(query) {
+        // This would call the LangSmith API
+        return [];
+    }
+
+    async getPrompt(promptId, variables = {}) {
+        // This would call the LangSmith API
+        return null;
+    }
+
+    async createPrompt(promptId, definition) {
+        // This would call the LangSmith API
+        return `https://smith.langchain.com/prompts/${promptId}`;
+    }
+
+    async updatePrompt(promptId, updates) {
+        // This would call the LangSmith API
+        return `https://smith.langchain.com/prompts/${promptId}`;
+    }
+
+    async deletePrompt(promptId) {
+        // This would call the LangSmith API
+    }
+}
+
+class MCPServer {
+    constructor(apiKey) {
+        this.manager = new PromptManager(apiKey);
+    }
+
+    async handleMessage(message) {
+        try {
+            const request = JSON.parse(message);
+            const response = await this.handleRequest(request);
+            return JSON.stringify(response);
+        } catch (error) {
+            return JSON.stringify({
+                jsonrpc: "2.0",
+                id: null,
+                error: {
+                    code: -32700,
+                    message: "Parse error"
+                }
+            });
+        }
+    }
+
+    async handleRequest(request) {
+        try {
+            switch (request.method) {
+                case "tools/list":
+                    const tools = [
+                        {
+                            name: "list_prompts",
+                            description: "List private prompts available in LangSmith",
+                            inputSchema: {
+                                type: "object",
+                                properties: {
+                                    query: {
+                                        type: "string",
+                                        description: "Filter prompts by repository or owner handle"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            name: "get_prompt",
+                            description: "Render a prompt locally, with optional variables",
+                            inputSchema: {
+                                type: "object",
+                                properties: {
+                                    promptId: {
+                                        type: "string",
+                                        description: "Prompt identifier (e.g. org/prompt-name)"
+                                    },
+                                    variables: {
+                                        type: "object",
+                                        description: "Optional prompt variables as key=value pairs",
+                                        additionalProperties: { type: "string" }
+                                    }
+                                },
+                                required: ["promptId"]
+                            }
+                        },
+                        {
+                            name: "create_prompt",
+                            description: "Create a new LangSmith prompt",
+                            inputSchema: {
+                                type: "object",
+                                properties: {
+                                    promptId: {
+                                        type: "string",
+                                        description: "Prompt identifier (e.g. org/prompt-name)"
+                                    },
+                                    template: {
+                                        type: "string",
+                                        description: "Prompt template content"
+                                    },
+                                    templateFormat: {
+                                        type: "string",
+                                        enum: ["mustache", "f-string"],
+                                        default: "mustache"
+                                    },
+                                    templateVariables: {
+                                        type: "array",
+                                        items: { type: "string" }
+                                    },
+                                    description: {
+                                        type: "string",
+                                        description: "Prompt description"
+                                    },
+                                    tags: {
+                                        type: "array",
+                                        items: { type: "string" }
+                                    },
+                                    readme: {
+                                        type: "string",
+                                        description: "Prompt README content"
+                                    },
+                                    isPublic: {
+                                        type: "boolean",
+                                        description: "Make the prompt public"
+                                    }
+                                },
+                                required: ["promptId", "template"]
+                            }
+                        },
+                        {
+                            name: "update_prompt",
+                            description: "Update an existing prompt with new content or metadata",
+                            inputSchema: {
+                                type: "object",
+                                properties: {
+                                    promptId: {
+                                        type: "string",
+                                        description: "Prompt identifier to update"
+                                    },
+                                    template: {
+                                        type: "string",
+                                        description: "Prompt template content"
+                                    },
+                                    templateFormat: {
+                                        type: "string",
+                                        enum: ["mustache", "f-string"]
+                                    },
+                                    templateVariables: {
+                                        type: "array",
+                                        items: { type: "string" }
+                                    },
+                                    description: {
+                                        type: "string",
+                                        description: "Prompt description"
+                                    },
+                                    tags: {
+                                        type: "array",
+                                        items: { type: "string" }
+                                    },
+                                    readme: {
+                                        type: "string",
+                                        description: "Prompt README content"
+                                    },
+                                    isPublic: {
+                                        type: "boolean",
+                                        description: "Mark the prompt as public or private"
+                                    }
+                                },
+                                required: ["promptId"]
+                            }
+                        },
+                        {
+                            name: "delete_prompt",
+                            description: "Delete a prompt after confirming it exists",
+                            inputSchema: {
+                                type: "object",
+                                properties: {
+                                    promptId: {
+                                        type: "string",
+                                        description: "Prompt identifier to delete"
+                                    }
+                                },
+                                required: ["promptId"]
+                            }
+                        }
+                    ];
+                    return {
+                        jsonrpc: "2.0",
+                        id: request.id,
+                        result: { tools }
+                    };
+
+                case "tools/call":
+                    const result = await this.handleToolCall(
+                        request.params.name,
+                        request.params.arguments
+                    );
+                    return {
+                        jsonrpc: "2.0",
+                        id: request.id,
+                        result: [{ type: "text", text: JSON.stringify(result, null, 2) }]
+                    };
+
+                default:
+                    return {
+                        jsonrpc: "2.0",
+                        id: request.id,
+                        error: {
+                            code: -32601,
+                            message: `Method ${request.method} not found`
+                        }
+                    };
+            }
+        } catch (error) {
+            return {
+                jsonrpc: "2.0",
+                id: request.id,
+                error: {
+                    code: -32603,
+                    message: error.message || "Unknown error"
+                }
+            };
+        }
+    }
+
+    async handleToolCall(name, args) {
+        switch (name) {
+            case "list_prompts":
+                return await this.manager.listPrompts(args.query);
+            case "get_prompt":
+                return await this.manager.getPrompt(args.promptId, args.variables || {});
+            case "create_prompt":
+                return await this.manager.createPrompt(args.promptId, args);
+            case "update_prompt":
+                return await this.manager.updatePrompt(args.promptId, args);
+            case "delete_prompt":
+                await this.manager.deletePrompt(args.promptId);
+                return { success: true };
+            default:
+                throw new Error(`Unknown tool: ${name}`);
+        }
+    }
+}
+
+// Vercel API route handler
+module.exports = async (req, res) => {
+    // Enable CORS
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
+    if (req.method === 'OPTIONS') {
+        res.statusCode = 200;
+        res.end();
+        return;
+    }
+
+    if (req.method === 'GET' && req.url === '/health') {
+        res.statusCode = 200;
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({ status: 'ok' }));
+        return;
+    }
+
+    if (req.method === 'POST' && req.url === '/mcp') {
+        try {
+            const body = req.body || '';
+            const mcpServer = new MCPServer(process.env.LANGSMITH_API_KEY);
+            const response = await mcpServer.handleMessage(body);
+            res.statusCode = 200;
+            res.setHeader('Content-Type', 'application/json');
+            res.end(response);
+        } catch (error) {
+            res.statusCode = 500;
+            res.setHeader('Content-Type', 'application/json');
+            res.end(JSON.stringify({
+                error: error.message || 'Internal server error'
+            }));
+        }
+        return;
+    }
+
+    res.statusCode = 404;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ error: 'Not found' }));
+};

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,38 @@
+# LangSmith Prompt Manager MCP Server
+# This server provides access to LangSmith prompts through the Model Context Protocol
+
+[server]
+name = "prompto-mcp"
+description = "Browse and render LangSmith prompts from the command line through MCP"
+url = "https://your-domain.vercel.app/mcp"
+method = "POST"
+
+[tools.list_prompts]
+description = "List private prompts available in LangSmith"
+parameters = { "type": "object", "properties": { "query": { "type": "string", "description": "Filter prompts by repository or owner handle" } } }
+
+[tools.get_prompt]
+description = "Render a prompt locally, with optional variables"
+parameters = { "type": "object", "properties": { "promptId": { "type": "string", "description": "Prompt identifier (e.g. org/prompt-name)" }, "variables": { "type": "object", "description": "Optional prompt variables as key=value pairs", "additionalProperties": { "type": "string" } } }, "required": ["promptId"] }
+
+[tools.create_prompt]
+description = "Create a new LangSmith prompt"
+parameters = { "type": "object", "properties": { "promptId": { "type": "string", "description": "Prompt identifier (e.g. org/prompt-name)" }, "template": { "type": "string", "description": "Prompt template content" }, "templateFormat": { "type": "string", "enum": ["mustache", "f-string"], "default": "mustache", "description": "Template format" }, "templateVariables": { "type": "array", "items": { "type": "string" }, "description": "Template variables" }, "description": { "type": "string", "description": "Prompt description" }, "tags": { "type": "array", "items": { "type": "string" }, "description": "Metadata tags" }, "readme": { "type": "string", "description": "Prompt README content" }, "isPublic": { "type": "boolean", "description": "Make the prompt public" } }, "required": ["promptId", "template"] }
+
+[tools.update_prompt]
+description = "Update an existing prompt with new content or metadata"
+parameters = { "type": "object", "properties": { "promptId": { "type": "string", "description": "Prompt identifier to update" }, "template": { "type": "string", "description": "Prompt template content" }, "templateFormat": { "type": "string", "enum": ["mustache", "f-string"], "description": "Template format" }, "templateVariables": { "type": "array", "items": { "type": "string" }, "description": "Template variables" }, "description": { "type": "string", "description": "Prompt description" }, "tags": { "type": "array", "items": { "type": "string" }, "description": "Metadata tags" }, "readme": { "type": "string", "description": "Prompt README content" }, "isPublic": { "type": "boolean", "description": "Mark the prompt as public or private" } }, "required": ["promptId"] }
+
+[tools.delete_prompt]
+description = "Delete a prompt after confirming it exists"
+parameters = { "type": "object", "properties": { "promptId": { "type": "string", "description": "Prompt identifier to delete" } }, "required": ["promptId"] }
+
+[environment]
+LANGSMITH_API_KEY = "your-langsmith-api-key-here"
+
+[examples]
+list_prompts = "List all available prompts"
+get_prompt = "Get and render a specific prompt with variables"
+create_prompt = "Create a new prompt with template and metadata"
+update_prompt = "Update an existing prompt's content or settings"
+delete_prompt = "Delete a prompt by its identifier"

--- a/package.json
+++ b/package.json
@@ -1,19 +1,26 @@
 {
-    "name": "prompto",
+    "name": "prompto-mcp",
+    "version": "1.0.0",
+    "description": "LangSmith Prompt Manager as an MCP server for xmcp.dev",
+    "main": "src/mcp-server.ts",
     "module": "./src/index.ts",
     "type": "module",
     "private": true,
     "scripts": {
-        "cli": "bun src/index.ts",
-        "compile": "bun build --compile src/index.ts --outfile dist/prompto",
-        "build": "bun build src/index.ts --target node --outfile dist/index.js",
+        "cli": "node src/index.ts",
+        "compile": "tsc src/index.ts --outDir dist",
+        "build": "tsc src/mcp-server.ts --target es2020 --module esnext --outDir dist",
+        "build:server": "tsc -p tsconfig.server.json",
+        "start": "node dist-server/src/mcp-server.js",
+        "dev": "node --loader ts-node/esm src/mcp-server.ts",
         "lint": "eslint . --ext .ts",
         "lint:fix": "eslint . --ext .ts --fix",
         "format": "prettier --write .",
         "format:check": "prettier --check .",
         "test": "vitest run",
         "test:watch": "vitest --watch",
-        "prepare": "husky"
+        "prepare": "husky",
+        "vercel-build": "echo 'Building for Vercel...' && npm run build:server"
     },
     "devDependencies": {
         "@types/bun": "latest",
@@ -24,6 +31,8 @@
         "eslint-config-prettier": "^10.1.8",
         "husky": "^9.1.7",
         "prettier": "^3.6.2",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.7.2",
         "typescript-eslint": "^8.44.1",
         "vitest": "^3.2.4"
     },

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1,0 +1,398 @@
+#!/usr/bin/env node
+import { createServer } from "http";
+import { parse } from "url";
+import { PromptManager } from "./manager.js";
+
+interface MCPSession {
+    id: string;
+    capabilities: {
+        tools: boolean;
+        resources: boolean;
+    };
+}
+
+interface MCPRequest {
+    jsonrpc: "2.0";
+    id?: string | number;
+    method: string;
+    params?: any;
+}
+
+interface MCPResponse {
+    jsonrpc: "2.0";
+    id: string | number;
+    result?: any;
+    error?: {
+        code: number;
+        message: string;
+        data?: any;
+    };
+}
+
+interface Tool {
+    name: string;
+    description: string;
+    inputSchema: {
+        type: "object";
+        properties: Record<string, any>;
+        required?: string[];
+    };
+}
+
+interface ListToolsRequest {
+    method: "tools/list";
+}
+
+interface CallToolRequest {
+    method: "tools/call";
+    params: {
+        name: string;
+        arguments: Record<string, any>;
+    };
+}
+
+interface ListPromptsArgs {
+    query?: string;
+}
+
+interface GetPromptArgs {
+    promptId: string;
+    variables?: Record<string, string>;
+}
+
+interface CreatePromptArgs {
+    promptId: string;
+    template: string;
+    templateFormat?: "mustache" | "f-string";
+    templateVariables?: string[];
+    description?: string;
+    tags?: string[];
+    readme?: string;
+    isPublic?: boolean;
+}
+
+interface UpdatePromptArgs {
+    promptId: string;
+    template?: string;
+    templateFormat?: "mustache" | "f-string";
+    templateVariables?: string[];
+    description?: string;
+    tags?: string[];
+    readme?: string;
+    isPublic?: boolean;
+}
+
+interface DeletePromptArgs {
+    promptId: string;
+}
+
+class MCPServer {
+    private manager: PromptManager;
+    private sessions: Map<string, MCPSession> = new Map();
+
+    constructor(apiKey: string) {
+        this.manager = new PromptManager(apiKey);
+    }
+
+    private getApiKey(): string {
+        const apiKey = process.env.LANGSMITH_API_KEY;
+        if (!apiKey) {
+            throw new Error("Missing LangSmith API key. Set LANGSMITH_API_KEY environment variable.");
+        }
+        return apiKey;
+    }
+
+    private async handleToolsList(): Promise<Tool[]> {
+        return [
+            {
+                name: "list_prompts",
+                description: "List private prompts available in LangSmith",
+                inputSchema: {
+                    type: "object",
+                    properties: {
+                        query: {
+                            type: "string",
+                            description: "Filter prompts by repository or owner handle"
+                        }
+                    }
+                }
+            },
+            {
+                name: "get_prompt",
+                description: "Render a prompt locally, with optional variables",
+                inputSchema: {
+                    type: "object",
+                    properties: {
+                        promptId: {
+                            type: "string",
+                            description: "Prompt identifier (e.g. org/prompt-name)"
+                        },
+                        variables: {
+                            type: "object",
+                            description: "Optional prompt variables as key=value pairs",
+                            additionalProperties: { type: "string" }
+                        }
+                    },
+                    required: ["promptId"]
+                }
+            },
+            {
+                name: "create_prompt",
+                description: "Create a new LangSmith prompt",
+                inputSchema: {
+                    type: "object",
+                    properties: {
+                        promptId: {
+                            type: "string",
+                            description: "Prompt identifier (e.g. org/prompt-name)"
+                        },
+                        template: {
+                            type: "string",
+                            description: "Prompt template content"
+                        },
+                        templateFormat: {
+                            type: "string",
+                            enum: ["mustache", "f-string"],
+                            default: "mustache",
+                            description: "Template format"
+                        },
+                        templateVariables: {
+                            type: "array",
+                            items: { type: "string" },
+                            description: "Template variables"
+                        },
+                        description: {
+                            type: "string",
+                            description: "Prompt description"
+                        },
+                        tags: {
+                            type: "array",
+                            items: { type: "string" },
+                            description: "Metadata tags"
+                        },
+                        readme: {
+                            type: "string",
+                            description: "Prompt README content"
+                        },
+                        isPublic: {
+                            type: "boolean",
+                            description: "Make the prompt public"
+                        }
+                    },
+                    required: ["promptId", "template"]
+                }
+            },
+            {
+                name: "update_prompt",
+                description: "Update an existing prompt with new content or metadata",
+                inputSchema: {
+                    type: "object",
+                    properties: {
+                        promptId: {
+                            type: "string",
+                            description: "Prompt identifier to update"
+                        },
+                        template: {
+                            type: "string",
+                            description: "Prompt template content"
+                        },
+                        templateFormat: {
+                            type: "string",
+                            enum: ["mustache", "f-string"],
+                            description: "Template format"
+                        },
+                        templateVariables: {
+                            type: "array",
+                            items: { type: "string" },
+                            description: "Template variables"
+                        },
+                        description: {
+                            type: "string",
+                            description: "Prompt description"
+                        },
+                        tags: {
+                            type: "array",
+                            items: { type: "string" },
+                            description: "Metadata tags"
+                        },
+                        readme: {
+                            type: "string",
+                            description: "Prompt README content"
+                        },
+                        isPublic: {
+                            type: "boolean",
+                            description: "Mark the prompt as public or private"
+                        }
+                    },
+                    required: ["promptId"]
+                }
+            },
+            {
+                name: "delete_prompt",
+                description: "Delete a prompt after confirming it exists",
+                inputSchema: {
+                    type: "object",
+                    properties: {
+                        promptId: {
+                            type: "string",
+                            description: "Prompt identifier to delete"
+                        }
+                    },
+                    required: ["promptId"]
+                }
+            }
+        ];
+    }
+
+    private async handleToolCall(name: string, args: any): Promise<any> {
+        switch (name) {
+            case "list_prompts":
+                return await this.manager.listPrompts(args.query);
+
+            case "get_prompt":
+                return await this.manager.getPrompt(args.promptId, args.variables || {});
+
+            case "create_prompt":
+                return await this.manager.createPrompt(args.promptId, args);
+
+            case "update_prompt":
+                return await this.manager.updatePrompt(args.promptId, args);
+
+            case "delete_prompt":
+                return await this.manager.deletePrompt(args.promptId);
+                return { success: true };
+
+            default:
+                throw new Error(`Unknown tool: ${name}`);
+        }
+    }
+
+    private async handleRequest(request: MCPRequest): Promise<MCPResponse> {
+        try {
+            switch (request.method) {
+                case "tools/list":
+                    const tools = await this.handleToolsList();
+                    return {
+                        jsonrpc: "2.0",
+                        id: request.id!,
+                        result: { tools }
+                    };
+
+                case "tools/call":
+                    const callRequest = request as MCPRequest & CallToolRequest;
+                    const result = await this.handleToolCall(
+                        callRequest.params.name,
+                        callRequest.params.arguments
+                    );
+                    return {
+                        jsonrpc: "2.0",
+                        id: request.id!,
+                        result: [{ type: "text", text: JSON.stringify(result, null, 2) }]
+                    };
+
+                default:
+                    return {
+                        jsonrpc: "2.0",
+                        id: request.id!,
+                        error: {
+                            code: -32601,
+                            message: `Method ${request.method} not found`
+                        }
+                    };
+            }
+        } catch (error) {
+            return {
+                jsonrpc: "2.0",
+                id: request.id!,
+                error: {
+                    code: -32603,
+                    message: error instanceof Error ? error.message : "Unknown error",
+                    data: error
+                }
+            };
+        }
+    }
+
+    async handleMessage(message: string): Promise<string> {
+        try {
+            const request: MCPRequest = JSON.parse(message);
+            const response = await this.handleRequest(request);
+            return JSON.stringify(response);
+        } catch (error) {
+            const errorResponse: MCPResponse = {
+                jsonrpc: "2.0",
+                id: null,
+                error: {
+                    code: -32700,
+                    message: "Parse error",
+                    data: error
+                }
+            };
+            return JSON.stringify(errorResponse);
+        }
+    }
+
+    getCapabilities(): MCPSession["capabilities"] {
+        return {
+            tools: true,
+            resources: false
+        };
+    }
+}
+
+// HTTP server for xmcp
+const server = createServer(async (req, res) => {
+    const { pathname } = parse(req.url!, true);
+
+    // Set CORS headers for xmcp.dev
+    res.setHeader("Access-Control-Allow-Origin", "*");
+    res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+    res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+
+    if (req.method === "OPTIONS") {
+        res.writeHead(200);
+        res.end();
+        return;
+    }
+
+    if (pathname === "/health") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ status: "ok" }));
+        return;
+    }
+
+    if (pathname === "/mcp") {
+        if (req.method !== "POST") {
+            res.writeHead(405, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ error: "Method not allowed" }));
+            return;
+        }
+
+        let body = "";
+        req.on("data", chunk => body += chunk);
+        req.on("end", async () => {
+            try {
+                const mcpServer = new MCPServer(process.env.LANGSMITH_API_KEY!);
+                const response = await mcpServer.handleMessage(body);
+                res.writeHead(200, { "Content-Type": "application/json" });
+                res.end(response);
+            } catch (error) {
+                res.writeHead(500, { "Content-Type": "application/json" });
+                res.end(JSON.stringify({
+                    error: error instanceof Error ? error.message : "Internal server error"
+                }));
+            }
+        });
+        return;
+    }
+
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Not found" }));
+});
+
+const port = process.env.PORT || 3000;
+server.listen(port, () => {
+    console.log(`MCP server listening on port ${port}`);
+    console.log(`Health check: http://localhost:${port}/health`);
+    console.log(`MCP endpoint: http://localhost:${port}/mcp`);
+});

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -1,0 +1,40 @@
+{
+    "compilerOptions": {
+        // Environment setup & latest features
+        "lib": ["ESNext"],
+        "target": "ES2020",
+        "module": "commonjs",
+        "moduleDetection": "force",
+        "jsx": "react-jsx",
+        "allowJs": true,
+        "esModuleInterop": true,
+        "allowSyntheticDefaultImports": true,
+
+        // Server mode
+        "moduleResolution": "node",
+        "allowImportingTsExtensions": false,
+        "verbatimModuleSyntax": false,
+        "noEmit": false,
+        "outDir": "./dist-server",
+        "rootDir": "./src",
+
+        // Best practices
+        "strict": true,
+        "skipLibCheck": true,
+        "noFallthroughCasesInSwitch": true,
+        "noUncheckedIndexedAccess": true,
+        "noImplicitOverride": true,
+
+        // Some stricter flags (disabled by default)
+        "noUnusedLocals": false,
+        "noUnusedParameters": false,
+        "noPropertyAccessFromIndexSignature": false,
+
+        // Additional server-specific settings
+        "resolveJsonModule": true,
+        "declaration": false,
+        "sourceMap": false
+    },
+    "include": ["src/**/*"],
+    "exclude": ["src/index.ts", "tests/**/*"]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,35 @@
+{
+    "version": 2,
+    "builds": [
+        {
+            "src": "api/mcp.js",
+            "use": "@vercel/node"
+        }
+    ],
+    "routes": [
+        {
+            "src": "/api/mcp",
+            "dest": "api/mcp.js"
+        },
+        {
+            "src": "/mcp",
+            "dest": "/api/mcp"
+        },
+        {
+            "src": "/health",
+            "dest": "/api/mcp"
+        },
+        {
+            "src": "/(.*)",
+            "dest": "/api/mcp"
+        }
+    ],
+    "env": {
+        "LANGSMITH_API_KEY": "@langsmith-api-key"
+    },
+    "functions": {
+        "api/mcp.js": {
+            "maxDuration": 30
+        }
+    }
+}


### PR DESCRIPTION
Add an MCP server entrypoint for Prompto to enable remote prompt management via xmcp.dev and Vercel deployment.

---
<a href="https://cursor.com/background-agent?bcId=bc-b22e60fb-a337-4514-919b-7d9f7758f9f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b22e60fb-a337-4514-919b-7d9f7758f9f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

