### PR TITLE
Fix vercel function runtime version error

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
         "typescript-eslint": "^8.44.1",
         "vitest": "^3.2.4"
     },
+    "engines": {
+        "node": "20.x"
+    },
     "peerDependencies": {
         "typescript": "^5"
     },

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,6 @@
 {
 	"functions": {
 		"api/[transport].ts": {
-			"runtime": "nodejs20.x",
 			"maxDuration": 60
 		}
 	},


### PR DESCRIPTION
Fix Vercel build error by specifying Node.js version in `package.json` and removing invalid runtime from `vercel.json`.

The Vercel build was failing with "Error: Function Runtimes must have a valid version". This was caused by an outdated `runtime` specification in `vercel.json`. Vercel now expects the Node.js version to be declared in the `engines` field of `package.json` for functions.

---
<a href="https://cursor.com/background-agent?bcId=bc-2beaefda-9fe0-4e01-8406-6243ffe3386b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2beaefda-9fe0-4e01-8406-6243ffe3386b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

